### PR TITLE
Cross out files with checked viewed box

### DIFF
--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -16,6 +16,7 @@ export const styleClass = {
   pageContainer: 'gde__page',
   activeFile: 'gde__file--active',
   activeExplorer: 'gde__item--active',
+  viewedExplorer: 'gde__item--viewed',
   explorerContainer: 'gde__container',
   minimizedContainer: 'gde__container--minimized',
   explorerHeader: 'gde__header',

--- a/src/modules/extension.js
+++ b/src/modules/extension.js
@@ -170,6 +170,8 @@ export default class Extension {
       const changedFile = {
         fileEl: data.el,
         explorerItemEl: getExplorerItemElementWithName(changedFileName),
+        fileViewed: data.viewed,
+        fileViewedButton: data.viewedButton,
       }
 
       const isValidAnchor = checkIfValidAnchor();
@@ -187,6 +189,38 @@ export default class Extension {
       changedFile.explorerItemEl.addEventListener('click', () => {
         this.clearActiveFile();
         this.setActiveFile(changedFile);
+      });
+
+      if (changedFile.fileViewed) {
+        changedFile.explorerItemEl.classList.add(styleClass.viewedExplorer);
+      }
+
+      changedFile.fileViewedButton.addEventListener('click', () => {
+        changedFile.fileViewed = !changedFile.fileViewed;
+
+        console.log(777);
+        console.log(changedFile.fileViewed);
+
+        if (changedFile.fileViewed) {
+          changedFile.explorerItemEl.classList.add(styleClass.viewedExplorer);
+          console.log(7);
+          console.log(styleClass.activeExplorer)
+          console.log(8)
+          console.log(styleClass.viewedExplorer)
+          console.log(9)
+          console.log(changedFile.explorerItemEl.classList);
+          console.log(10)
+          console.log(changedFile.fileEl)
+          console.log(11)
+        } else {
+          changedFile.explorerItemEl.classList.remove(styleClass.viewedExplorer);
+        }
+
+        changedFile.fileViewedButton = changedFile.fileEl.children[0].getElementsByClassName('js-reviewed-checkbox');
+        
+        
+        console.log(changedFile.fileEl.children[0].getElementsByClassName('js-reviewed-checkbox'));
+        console.log(changedFile.fileEl.children[0].getElementsByClassName('js-reviewed-checkbox')[0]);
       });
 
       const reducer = (acc, path) => {

--- a/src/modules/extension.js
+++ b/src/modules/extension.js
@@ -170,7 +170,6 @@ export default class Extension {
       const changedFile = {
         fileEl: data.el,
         explorerItemEl: getExplorerItemElementWithName(changedFileName),
-        fileViewed: data.viewed,
       }
 
       const isValidAnchor = checkIfValidAnchor();
@@ -190,23 +189,21 @@ export default class Extension {
         this.setActiveFile(changedFile);
       });
 
-      if (changedFile.fileViewed) {
-        changedFile.explorerItemEl.classList.add(styleClass.viewedExplorer);
+      let fileViewed = this.isViewedFile(changedFile);
+      const fileHeader = changedFile.fileEl.children[0];
+
+      if (fileViewed) {
+        this.addViewedFile(changedFile);
       }
 
-      changedFile.fileEl.children[0].addEventListener('click', () => {
-
+      fileHeader.addEventListener('click', () => {
         if (event.target.classList.contains('js-reviewed-checkbox')) {
+          fileViewed = !fileViewed;
 
-          changedFile.fileViewed = !changedFile.fileViewed;
-
-          console.log(777);
-          console.log(changedFile.fileViewed);
-
-          if (changedFile.fileViewed) {
-            changedFile.explorerItemEl.classList.add(styleClass.viewedExplorer);
+          if (fileViewed) {
+            this.addViewedFile(changedFile)
           } else {
-            changedFile.explorerItemEl.classList.remove(styleClass.viewedExplorer);
+            this.removeViewedFile(changedFile)
           }
         }
       });
@@ -232,5 +229,19 @@ export default class Extension {
   clearActiveFile() {
     this.activeFileEl.classList.remove(styleClass.activeFile);
     this.activeExplorerEl.classList.remove(styleClass.activeExplorer);
+  }
+
+  isViewedFile(file) {
+    return file.fileEl.children[0].getElementsByClassName('js-reviewed-checkbox')[0].getAttribute('data-ga-click').includes("true")
+  }
+
+  addViewedFile(file) {
+    this.viewedExplorerEl = file.explorerItemEl;
+    this.viewedExplorerEl.classList.add(styleClass.viewedExplorer);
+  }
+
+  removeViewedFile(file) {
+    this.viewedExplorerEl = file.explorerItemEl;
+    this.viewedExplorerEl.classList.remove(styleClass.viewedExplorer);
   }
 }

--- a/src/modules/extension.js
+++ b/src/modules/extension.js
@@ -171,7 +171,6 @@ export default class Extension {
         fileEl: data.el,
         explorerItemEl: getExplorerItemElementWithName(changedFileName),
         fileViewed: data.viewed,
-        fileViewedButton: data.viewedButton,
       }
 
       const isValidAnchor = checkIfValidAnchor();
@@ -195,32 +194,21 @@ export default class Extension {
         changedFile.explorerItemEl.classList.add(styleClass.viewedExplorer);
       }
 
-      changedFile.fileViewedButton.addEventListener('click', () => {
-        changedFile.fileViewed = !changedFile.fileViewed;
+      changedFile.fileEl.children[0].addEventListener('click', () => {
 
-        console.log(777);
-        console.log(changedFile.fileViewed);
+        if (event.target.classList.contains('js-reviewed-checkbox')) {
 
-        if (changedFile.fileViewed) {
-          changedFile.explorerItemEl.classList.add(styleClass.viewedExplorer);
-          console.log(7);
-          console.log(styleClass.activeExplorer)
-          console.log(8)
-          console.log(styleClass.viewedExplorer)
-          console.log(9)
-          console.log(changedFile.explorerItemEl.classList);
-          console.log(10)
-          console.log(changedFile.fileEl)
-          console.log(11)
-        } else {
-          changedFile.explorerItemEl.classList.remove(styleClass.viewedExplorer);
+          changedFile.fileViewed = !changedFile.fileViewed;
+
+          console.log(777);
+          console.log(changedFile.fileViewed);
+
+          if (changedFile.fileViewed) {
+            changedFile.explorerItemEl.classList.add(styleClass.viewedExplorer);
+          } else {
+            changedFile.explorerItemEl.classList.remove(styleClass.viewedExplorer);
+          }
         }
-
-        changedFile.fileViewedButton = changedFile.fileEl.children[0].getElementsByClassName('js-reviewed-checkbox');
-        
-        
-        console.log(changedFile.fileEl.children[0].getElementsByClassName('js-reviewed-checkbox'));
-        console.log(changedFile.fileEl.children[0].getElementsByClassName('js-reviewed-checkbox')[0]);
       });
 
       const reducer = (acc, path) => {

--- a/src/modules/structure.js
+++ b/src/modules/structure.js
@@ -14,7 +14,6 @@ export function extractPathDataFromElements(elements) {
     return {
       path: el.children[0].dataset.path,
       anchor: el.children[0].dataset.anchor,
-      viewed: el.children[0].getElementsByClassName('js-reviewed-checkbox')[0].getAttribute('data-ga-click').includes("true"),
       el: el,
     };
   });

--- a/src/modules/structure.js
+++ b/src/modules/structure.js
@@ -14,6 +14,8 @@ export function extractPathDataFromElements(elements) {
     return {
       path: el.children[0].dataset.path,
       anchor: el.children[0].dataset.anchor,
+      viewedButton: el.children[0].getElementsByClassName('js-reviewed-checkbox')[0],
+      viewed: el.children[0].getElementsByClassName('js-reviewed-checkbox')[0].getAttribute('data-ga-click').includes("true"),
       el: el,
     };
   });

--- a/src/modules/structure.js
+++ b/src/modules/structure.js
@@ -14,7 +14,6 @@ export function extractPathDataFromElements(elements) {
     return {
       path: el.children[0].dataset.path,
       anchor: el.children[0].dataset.anchor,
-      viewedButton: el.children[0].getElementsByClassName('js-reviewed-checkbox')[0],
       viewed: el.children[0].getElementsByClassName('js-reviewed-checkbox')[0].getAttribute('data-ga-click').includes("true"),
       el: el,
     };

--- a/src/styles.css
+++ b/src/styles.css
@@ -227,6 +227,10 @@
   color: #36BC53;
 }
 
+.gde__item--viewed {
+  text-decoration: line-through;
+}
+
 .gde__folder-closed + .gde__nested-files {
   display: none;
 }


### PR DESCRIPTION

Added strike through for the file names in explorer whose viewed boxes have been checked, as referenced in #26. 

I am really enjoying the extension but I was missing this feature, so I figured I would see if I could add it myself, and I think I've got the functionality figured out. I've only recently started getting my feet wet with JavaScript, and this is my first time working on an extension, so certainly open to any and all feedback.